### PR TITLE
Update FfmpegCutAndFrames.ps1

### DIFF
--- a/FfmpegCutAndFrames.ps1
+++ b/FfmpegCutAndFrames.ps1
@@ -1,15 +1,78 @@
-$inputFile = "C:\path\to\input\video.mp4"
-$outputFolder = "C:\path\to\output\folder"
-$startTime = "00:00:10"   # Replace with the desired start time in HH:MM:SS format
-$endTime = "00:00:20"     # Replace with the desired end time in HH:MM:SS format
+# Improved version of FfmpegCutAndFrames.ps1
+# This script trims a video between a start and end time and extracts frames as images.
+# It accepts parameters for input file, output directory, start time and end time. It also
+# performs basic validation and creates the output directory if it does not exist.
 
-New-Item -ItemType Directory -Force -Path $outputFolder | Out-Null
-$ffprobeOutput = ffmpeg -i $inputFile -show_entries frame=pkt_pts_time,pict_type -of csv -select_streams v:0 -v quiet -show_entries frame=pkt_pts_time,pict_type -of csv=p=0
-$lastKeyframeTime = ($ffprobeOutput | ConvertFrom-Csv | Where-Object { $_.pict_type -eq "I" -and $_.pkt_pts_time -lt $endTime } | Select-Object -Last 1).pkt_pts_time
-if ($lastKeyframeTime -eq $null) {
-    $lastKeyframeTime = $endTime
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$InputFile,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]$OutputFolder,
+
+    [Parameter(Mandatory=$true, Position=2)]
+    [ValidatePattern("^\d{2}:\d{2}:\d{2}(\.\d{1,3})?$", ErrorMessage="StartTime must be in HH:MM:SS[.fff] format")]
+    [string]$StartTime,
+
+    [Parameter(Mandatory=$true, Position=3)]
+    [ValidatePattern("^\d{2}:\d{2}:\d{2}(\.\d{1,3})?$", ErrorMessage="EndTime must be in HH:MM:SS[.fff] format")]
+    [string]$EndTime
+)
+
+# Validate that ffmpeg and ffprobe are available
+function Test-Command {
+    param([string]$Command)
+    $exists = Get-Command $Command -ErrorAction SilentlyContinue
+    return [bool]$exists
 }
-$extendedEndTime = [TimeSpan]::Parse($lastKeyframeTime).ToString("hh\:mm\:ss\.fff")
 
-ffmpeg -i $inputFile -ss $startTime -to $extendedEndTime -c:v copy -c:a copy "$outputFolder\output.mp4"
-ffmpeg -i "$outputFolder\output.mp4" -vsync 0 "$outputFolder\frame-%d.png"
+if (-not (Test-Command 'ffmpeg')) {
+    Write-Error "ffmpeg is not installed or not found in PATH. Please install ffmpeg to continue."
+    exit 1
+}
+if (-not (Test-Command 'ffprobe')) {
+    Write-Error "ffprobe is not installed or not found in PATH. Please install ffprobe to continue."
+    exit 1
+}
+
+# Validate input file
+if (-not (Test-Path -Path $InputFile -PathType Leaf)) {
+    Write-Error "Input file '$InputFile' does not exist."
+    exit 1
+}
+
+# Create output directory if it does not exist
+if (-not (Test-Path -Path $OutputFolder -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputFolder -Force | Out-Null
+}
+
+# Determine the last keyframe time (for informational purposes)
+try {
+    $frames = & ffprobe -select_streams v:0 -show_frames -show_entries frame=pict_type,pkt_pts_time -of csv -v quiet $InputFile |
+        ConvertFrom-Csv -Header 'pict_type','pkt_pts_time'
+    $lastKeyFrame = ($frames | Where-Object { $_.pict_type -eq 'I' } | Select-Object -Last 1).pkt_pts_time
+    Write-Host "Last keyframe time detected: $lastKeyFrame"
+} catch {
+    Write-Warning "Unable to detect last keyframe time: $_"
+}
+
+# Define names for temporary and final outputs
+$trimmedVideo = Join-Path $OutputFolder 'trimmed_output.mp4'
+$framesOutputPattern = Join-Path $OutputFolder 'frame-%04d.png'
+
+# Trim the video to the specified segment
+Write-Host "Trimming video from $StartTime to $EndTime..."
+$trimArgs = @('-hide_banner', '-loglevel', 'error', '-ss', $StartTime, '-to', $EndTime, '-i', $InputFile, '-c:v', 'copy', '-c:a', 'copy', $trimmedVideo)
+& ffmpeg @trimArgs
+
+if (-not (Test-Path -Path $trimmedVideo -PathType Leaf)) {
+    Write-Error "Failed to create trimmed video."
+    exit 1
+}
+
+# Extract frames
+Write-Host "Extracting frames to $OutputFolder..."
+$frameArgs = @('-hide_banner', '-loglevel', 'error', '-i', $trimmedVideo, '-vsync', '0', $framesOutputPattern)
+& ffmpeg @frameArgs
+
+Write-Host "Processing complete. Trimmed video and frames saved in '$OutputFolder'."


### PR DESCRIPTION
This pull request updates the script `FfmpegCutAndFrames.ps1` with a more robust and user-friendly version. The updated script adds parameter support for the input file, output folder, start time and end time. It validates that `ffmpeg` and `ffprobe` are installed and checks that the input file exists. The script creates the output directory if needed, uses `ffprobe` to determine the last keyframe time, trims the video using `ffmpeg` and extracts frames. It includes basic error handling and cleaner logging.
